### PR TITLE
feat(router): add Router() method and GetRouter helper function

### DIFF
--- a/apirouter/router.go
+++ b/apirouter/router.go
@@ -4,4 +4,5 @@ type Router[HandlerFunc any, Route any] interface {
 	AddRoute(method string, path string, handler HandlerFunc) Route
 	SwaggerHandler(contentType string, blob []byte) HandlerFunc
 	TransformPathToOasPath(path string) string
+	Router() any
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,14 @@ var (
 	ErrValidatingSwagger = ErrValidatingOAS
 )
 
+// GetRouter returns the underlying router instance cast to the specified type.
+// This provides type-safe access to the concrete router implementation.
+// Example:
+//   router := GetRouter[*mux.Router](swaggerRouter)
+func GetRouter[T any, H any, R any](r apirouter.Router[H, R]) T {
+	return r.Router().(T)
+}
+
 const (
 	// DefaultJSONDocumentationPath is the path of the openapi documentation in json format.
 	DefaultJSONDocumentationPath = "/documentation/json"

--- a/main_test.go
+++ b/main_test.go
@@ -433,6 +433,42 @@ func TestGenerateAndExposeSwagger(t *testing.T) {
 	})
 }
 
+func TestGetRouter(t *testing.T) {
+	t.Run("gets gorilla router instance", func(t *testing.T) {
+		muxRouter := mux.NewRouter()
+		gorillaRouter := gorilla.NewRouter(muxRouter)
+		router, err := NewRouter(gorillaRouter, Options{
+			Openapi: &openapi3.T{
+				Info: &openapi3.Info{
+					Title:   "test",
+					Version: "1.0",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		muxRouterFromGetter := GetRouter[*mux.Router](router.Router())
+		require.Equal(t, muxRouter, muxRouterFromGetter)
+	})
+
+	t.Run("panics on wrong type", func(t *testing.T) {
+		muxRouter := mux.NewRouter()
+		router, err := NewRouter(gorilla.NewRouter(muxRouter), Options{
+			Openapi: &openapi3.T{
+				Info: &openapi3.Info{
+					Title:   "test",
+					Version: "1.0",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		require.Panics(t, func() {
+			_ = GetRouter[string](router.Router())
+		})
+	})
+}
+
 func readBody(t *testing.T, requestBody io.ReadCloser) string {
 	t.Helper()
 

--- a/support/echo/echo.go
+++ b/support/echo/echo.go
@@ -29,6 +29,10 @@ func (r echoRouter) TransformPathToOasPath(path string) string {
 	return apirouter.TransformPathParamsWithColon(path)
 }
 
+func (r echoRouter) Router() any {
+	return r.router
+}
+
 func NewRouter(router *echo.Echo) apirouter.Router[echo.HandlerFunc, Route] {
 	return echoRouter{
 		router: router,

--- a/support/fiber/fiber.go
+++ b/support/fiber/fiber.go
@@ -12,6 +12,10 @@ type fiberRouter struct {
 	router fiber.Router
 }
 
+func (r fiberRouter) Router() any {
+	return r.router
+}
+
 func NewRouter(router fiber.Router) apirouter.Router[HandlerFunc, Route] {
 	return fiberRouter{
 		router: router,

--- a/support/gorilla/gorilla.go
+++ b/support/gorilla/gorilla.go
@@ -32,6 +32,10 @@ func (r gorillaRouter) TransformPathToOasPath(path string) string {
 	return path
 }
 
+func (r gorillaRouter) Router() any {
+	return r.router
+}
+
 func NewRouter(router *mux.Router) apirouter.Router[HandlerFunc, Route] {
 	return gorillaRouter{
 		router: router,


### PR DESCRIPTION
- Added Router() any method to apirouter.Router interface
- Implemented Router() method in all router implementations (echo, fiber, gorilla)
- Added new GetRouter[T] helper function for type-safe access to underlying router
- Added tests for GetRouter functionality