### PR TITLE
feat: add middleware support to router interface

### DIFF
--- a/apirouter/router.go
+++ b/apirouter/router.go
@@ -1,9 +1,10 @@
 package apirouter
 
-type Router[HandlerFunc any, Route any] interface {
-	AddRoute(method string, path string, handler HandlerFunc) Route
+type Router[HandlerFunc any, MiddlewareFunc any, Route any] interface {
+	AddRoute(method string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) Route
 	SwaggerHandler(contentType string, blob []byte) HandlerFunc
 	TransformPathToOasPath(path string) string
 	Router() any
-	Group(pathPrefix string) Router[HandlerFunc, Route]
+	Group(pathPrefix string) Router[HandlerFunc, MiddlewareFunc, Route]
+	Use(middleware ...MiddlewareFunc)
 }

--- a/route_test.go
+++ b/route_test.go
@@ -15,7 +15,7 @@ import (
 	"go.lumeweb.com/gswagger/support/testutils"
 )
 
-type TestRouter = Router[gorilla.HandlerFunc, gorilla.Route]
+type TestRouter = Router[gorilla.HandlerFunc, mux.MiddlewareFunc, gorilla.Route]
 
 var muxRouter *mux.Router
 

--- a/support/echo/echo_test.go
+++ b/support/echo/echo_test.go
@@ -11,12 +11,63 @@ import (
 	"go.lumeweb.com/gswagger/apirouter"
 )
 
-func TestGorillaMuxRouter(t *testing.T) {
+func TestEchoRouter(t *testing.T) {
 	echoRouter := echo.New()
 	ar := NewRouter(echoRouter)
 
+	t.Run("middleware is applied via Use", func(t *testing.T) {
+		middlewareCalled := false
+		middleware := func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				middlewareCalled = true
+				return next(c)
+			}
+		}
+
+		ar.Use(middleware)
+		ar.AddRoute(http.MethodGet, "/middleware", func(c echo.Context) error {
+			return c.String(http.StatusOK, "")
+		})
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/middleware", nil)
+		echoRouter.ServeHTTP(w, r)
+
+		require.True(t, middlewareCalled)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("middleware is applied via AddRoute", func(t *testing.T) {
+		mw1Called := false
+		mw2Called := false
+		mw1 := func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				mw1Called = true
+				return next(c)
+			}
+		}
+		mw2 := func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				mw2Called = true
+				return next(c)
+			}
+		}
+
+		ar.AddRoute(http.MethodGet, "/route-mw", func(c echo.Context) error {
+			return c.String(http.StatusOK, "")
+		}, mw1, mw2)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/route-mw", nil)
+		echoRouter.ServeHTTP(w, r)
+
+		require.True(t, mw1Called)
+		require.True(t, mw2Called)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
 	t.Run("create a new api router", func(t *testing.T) {
-		require.Implements(t, (*apirouter.Router[echo.HandlerFunc, Route])(nil), ar)
+		require.Implements(t, (*apirouter.Router[echo.HandlerFunc, echo.MiddlewareFunc, Route])(nil), ar)
 	})
 
 	t.Run("add new route", func(t *testing.T) {

--- a/support/echo/integration_test.go
+++ b/support/echo/integration_test.go
@@ -22,7 +22,7 @@ const (
 	swaggerOpenapiVersion = "test openapi version"
 )
 
-type echoSwaggerRouter = swagger.Router[echo.HandlerFunc, *echo.Route]
+type echoSwaggerRouter = swagger.Router[echo.HandlerFunc, echo.HandlerFunc, *echo.Route]
 
 func TestEchoIntegration(t *testing.T) {
 	t.Run("router works correctly - echo", func(t *testing.T) {
@@ -127,7 +127,7 @@ func readBody(t *testing.T, requestBody io.ReadCloser) string {
 	return string(body)
 }
 
-func setupEchoSwagger(t *testing.T) (*echo.Echo, *echoSwaggerRouter) {
+func setupEchoSwagger(t *testing.T) (*echo.Echo, *swagger.Router[echo.HandlerFunc, echo.MiddlewareFunc, *echo.Route]) {
 	t.Helper()
 
 	context := context.Background()

--- a/support/fiber/fiber.go
+++ b/support/fiber/fiber.go
@@ -10,7 +10,7 @@ import (
 type HandlerFunc = fiber.Handler
 type Route = fiber.Router
 
-var _ apirouter.Router[HandlerFunc, Route] = (*fiberRouter)(nil)
+var _ apirouter.Router[HandlerFunc, HandlerFunc, Route] = (*fiberRouter)(nil)
 
 type fiberRouter struct {
 	router     fiber.Router // Can be *fiber.App or fiber.Router (from Group)
@@ -21,17 +21,17 @@ func (r fiberRouter) Router() any {
 	return r.router
 }
 
-func NewRouter(router fiber.Router) apirouter.Router[HandlerFunc, Route] {
+func NewRouter(router fiber.Router) apirouter.Router[HandlerFunc, HandlerFunc, Route] {
 	return fiberRouter{
 		router: router,
 	}
 }
 
-func (r fiberRouter) Group(pathPrefix string) apirouter.Router[HandlerFunc, Route] {
+func (r fiberRouter) Group(pathPrefix string) apirouter.Router[HandlerFunc, HandlerFunc, Route] {
 	// Ensure path prefix starts with / and doesn't end with /
 	cleanPrefix := strings.TrimPrefix(pathPrefix, "/")
 	cleanPrefix = strings.TrimSuffix(cleanPrefix, "/")
-	
+
 	fiberGroup := r.router.Group("/" + cleanPrefix)
 	return fiberRouter{
 		router:     fiberGroup,
@@ -39,8 +39,11 @@ func (r fiberRouter) Group(pathPrefix string) apirouter.Router[HandlerFunc, Rout
 	}
 }
 
-func (r fiberRouter) AddRoute(method string, path string, handler HandlerFunc) Route {
-	return r.router.Add(method, path, handler)
+func (r fiberRouter) AddRoute(method string, path string, handler HandlerFunc, middleware ...HandlerFunc) Route {
+	handlers := make([]HandlerFunc, 0, len(middleware)+1)
+	handlers = append(handlers, middleware...)
+	handlers = append(handlers, handler)
+	return r.router.Add(method, path, handlers...)
 }
 
 func (r fiberRouter) SwaggerHandler(contentType string, blob []byte) HandlerFunc {
@@ -50,6 +53,10 @@ func (r fiberRouter) SwaggerHandler(contentType string, blob []byte) HandlerFunc
 	}
 }
 
+func (r fiberRouter) Use(middleware ...HandlerFunc) {
+	useMiddleware(r.router, middleware...)
+}
+
 func (r fiberRouter) TransformPathToOasPath(path string) string {
 	// If this is a subrouter, the path is relative to the prefix.
 	// We need to prepend the prefix for the OpenAPI path.
@@ -57,4 +64,14 @@ func (r fiberRouter) TransformPathToOasPath(path string) string {
 		return apirouter.TransformPathParamsWithColon(r.pathPrefix + path)
 	}
 	return apirouter.TransformPathParamsWithColon(path)
+}
+
+func useMiddleware(router fiber.Router, middleware ...HandlerFunc) fiber.Router {
+	if len(middleware) > 0 {
+		for _, mw := range middleware {
+			router.Use(mw)
+		}
+	}
+
+	return router
 }

--- a/support/fiber/integration_test.go
+++ b/support/fiber/integration_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type SwaggerRouter = swagger.Router[oasFiber.HandlerFunc, oasFiber.Route]
+type SwaggerRouter = swagger.Router[oasFiber.HandlerFunc, fiber.Handler, oasFiber.Route]
 
 const (
 	swaggerOpenapiTitle   = "test openapi title"
@@ -114,7 +114,7 @@ func TestFiberIntegration(t *testing.T) {
 	})
 }
 
-func setupSwagger(t *testing.T) (*fiber.App, *SwaggerRouter) {
+func setupSwagger(t *testing.T) (*fiber.App, *swagger.Router[oasFiber.HandlerFunc, fiber.Handler, oasFiber.Route]) {
 	t.Helper()
 
 	context := context.Background()

--- a/support/gorilla/gorilla.go
+++ b/support/gorilla/gorilla.go
@@ -12,14 +12,32 @@ import (
 type HandlerFunc func(w http.ResponseWriter, req *http.Request)
 type Route = *mux.Route
 
-var _ apirouter.Router[HandlerFunc, Route] = (*gorillaRouter)(nil)
+var _ apirouter.Router[HandlerFunc, mux.MiddlewareFunc, Route] = (*gorillaRouter)(nil)
+
+func NewRouter(router *mux.Router) apirouter.Router[HandlerFunc, mux.MiddlewareFunc, Route] {
+	return gorillaRouter{
+		router:  router,
+		inGroup: false,
+	}
+}
+
+func (r gorillaRouter) Use(middleware ...mux.MiddlewareFunc) {
+	r.router.Use(middleware...)
+}
 
 type gorillaRouter struct {
 	router     *mux.Router // Can be main router or subrouter
 	pathPrefix string
+	inGroup    bool // Flag to prevent infinite recursion
 }
 
-func (r gorillaRouter) AddRoute(method string, path string, handler HandlerFunc) Route {
+func (r gorillaRouter) AddRoute(method string, path string, handler HandlerFunc, middleware ...mux.MiddlewareFunc) Route {
+	// Use group API consistently for middleware handling
+	if len(middleware) > 0 && !r.inGroup {
+		group := r.Group("")
+		group.Use(middleware...)
+		return group.AddRoute(method, path, handler)
+	}
 	return r.router.HandleFunc(path, handler).Methods(method)
 }
 
@@ -39,13 +57,7 @@ func (r gorillaRouter) Router() any {
 	return r.router
 }
 
-func NewRouter(router *mux.Router) apirouter.Router[HandlerFunc, Route] {
-	return gorillaRouter{
-		router: router,
-	}
-}
-
-func (r gorillaRouter) Group(pathPrefix string) apirouter.Router[HandlerFunc, Route] {
+func (r gorillaRouter) Group(pathPrefix string) apirouter.Router[HandlerFunc, mux.MiddlewareFunc, Route] {
 	// Ensure path prefix starts with / and doesn't end with /
 	cleanPrefix := strings.TrimPrefix(pathPrefix, "/")
 	cleanPrefix = strings.TrimSuffix(cleanPrefix, "/")
@@ -61,5 +73,6 @@ func (r gorillaRouter) Group(pathPrefix string) apirouter.Router[HandlerFunc, Ro
 	return gorillaRouter{
 		router:     muxSubrouter,
 		pathPrefix: fullPrefix,
+		inGroup:    true, // Mark as being in a group
 	}
 }

--- a/support/gorilla/gorilla_test.go
+++ b/support/gorilla/gorilla_test.go
@@ -15,8 +15,73 @@ func TestGorillaMuxRouter(t *testing.T) {
 	muxRouter := mux.NewRouter()
 	ar := NewRouter(muxRouter)
 
+	t.Run("middleware is applied via Use", func(t *testing.T) {
+		middlewareCalled := false
+		middleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				middlewareCalled = true
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		ar.Use(middleware)
+		ar.AddRoute(http.MethodGet, "/middleware", func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/middleware", nil)
+		muxRouter.ServeHTTP(w, r)
+
+		require.True(t, middlewareCalled)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("middleware is applied via AddRoute", func(t *testing.T) {
+		// Create a fresh router for this test to avoid middleware leaking
+		testRouter := mux.NewRouter()
+		testAR := NewRouter(testRouter)
+
+		mw1Called := false
+		mw2Called := false
+		mw1 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mw1Called = true
+				next.ServeHTTP(w, r)
+			})
+		}
+		mw2 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mw2Called = true
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		testAR.AddRoute(http.MethodGet, "/route-mw", func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}, mw1, mw2)
+
+		// Test middleware is called for the intended route
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/route-mw", nil)
+		testRouter.ServeHTTP(w, r)
+
+		require.True(t, mw1Called)
+		require.True(t, mw2Called)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		// Verify middleware isn't called for other routes
+		mw1Called = false
+		mw2Called = false
+		w = httptest.NewRecorder()
+		r = httptest.NewRequest(http.MethodGet, "/other-route", nil)
+		testRouter.ServeHTTP(w, r)
+		require.False(t, mw1Called)
+		require.False(t, mw2Called)
+	})
+
 	t.Run("create a new api router", func(t *testing.T) {
-		require.Implements(t, (*apirouter.Router[HandlerFunc, Route])(nil), ar)
+		require.Implements(t, (*apirouter.Router[HandlerFunc, mux.MiddlewareFunc, Route])(nil), ar)
 	})
 
 	t.Run("add new route", func(t *testing.T) {

--- a/support/gorilla/integration_test.go
+++ b/support/gorilla/integration_test.go
@@ -21,7 +21,7 @@ const (
 	swaggerOpenapiVersion = "test openapi version"
 )
 
-type SwaggerRouter = swagger.Router[gorilla.HandlerFunc, gorilla.Route]
+type SwaggerRouter = swagger.Router[gorilla.HandlerFunc, mux.MiddlewareFunc, gorilla.Route]
 
 func TestGorillaIntegration(t *testing.T) {
 	t.Run("router works correctly", func(t *testing.T) {


### PR DESCRIPTION
- Extended Router interface to support middleware functions
- Updated all router implementations (gorilla, echo, fiber) to handle middleware
- Added middleware tests for each router implementation
- Modified AddRoute methods to accept variadic middleware parameters
- Added Use() method to router interface for global middleware
- Updated type parameters to include MiddlewareFunc type
- Maintained backward compatibility with existing routes