### PR TITLE
fix: correct type parameters order in GetRouter and fix test naming

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 // Example:
 //
 //	router := GetRouter[*mux.Router](swaggerRouter)
-func GetRouter[T any, H any, R any, M any](r apirouter.Router[H, R, M]) T {
+func GetRouter[T any, H any, M any, R any](r apirouter.Router[H, M, R]) T {
 	return r.Router().(T)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestMiddleware(t *testing.T) {
-	muxRouter := mux.NewRouter()
-	mAPIRouter := gorilla.NewRouter(muxRouter)
+	_mux := mux.NewRouter()
+	mAPIRouter := gorilla.NewRouter(_mux)
 
 	info := &openapi3.Info{
 		Title:   "middleware test",
@@ -56,7 +56,7 @@ func TestMiddleware(t *testing.T) {
 	})
 }
 
-func TestMiddleware(t *testing.T) {
+func TestMiddlewareViaUseAndAddRoute(t *testing.T) {
 	muxRouter := mux.NewRouter()
 	mAPIRouter := gorilla.NewRouter(muxRouter)
 


### PR DESCRIPTION
- Fixed type parameter ordering in GetRouter function (H, M, R instead of H, R, M)
- Renamed duplicate TestMiddleware function to TestMiddlewareViaUseAndAddRoute
- Minor variable renaming in test (_mux instead of muxRouter)