### PR TITLE
feat: add SetInfo method to modify OpenAPI metadata

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,6 +182,18 @@ func (r *Router[HandlerFunc, MiddlewareFunc, Route]) SwaggerSchema(schema *opena
 	return r
 }
 
+// SetInfo sets the OpenAPI Info struct (title, version, description etc) for the router.
+// This allows modifying the API metadata after router creation.
+// Returns the router instance for method chaining.
+// If info is nil, the method is a no-op and returns the router unchanged.
+func (r *Router[HandlerFunc, MiddlewareFunc, Route]) SetInfo(info *openapi3.Info) *Router[HandlerFunc, MiddlewareFunc, Route] {
+	if info == nil {
+		return r
+	}
+	r.swaggerSchema.Info = info
+	return r
+}
+
 type Options[HandlerFunc any, MiddlewareFunc any, Route any] struct {
 	Context context.Context
 	Openapi *openapi3.T


### PR DESCRIPTION
- Added SetInfo method to Router struct allowing modification of OpenAPI Info (title, version, description)
- Supports method chaining by returning router instance
- Added comprehensive tests covering:
  - Setting info on root, host and sub routers
  - Validation of required fields (title and version)
  - Proper schema sharing between parent/child routers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to update OpenAPI metadata (such as title, version, and description) for routers after creation.

- **Tests**
	- Introduced new tests to verify updating and validating OpenAPI metadata on different router types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->