### PR TITLE
refactor: improve OpenAPI schema handling and reference resolution

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -173,10 +173,8 @@ func TestFiberNewRouter(t *testing.T) {
 			yamlDocumentationPath: DefaultYAMLDocumentationPath,
 			hostRouters:           make(map[string]*Router[fiber.Handler, fiber.Handler, gfiber.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 
@@ -197,10 +195,8 @@ func TestFiberNewRouter(t *testing.T) {
 			yamlDocumentationPath: DefaultYAMLDocumentationPath,
 			hostRouters:           make(map[string]*Router[fiber.Handler, fiber.Handler, gfiber.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 
@@ -208,8 +204,8 @@ func TestFiberNewRouter(t *testing.T) {
 		type key struct{}
 		ctx := context.WithValue(context.Background(), key{}, "value")
 		r, err := NewRouter(fiberRouter, Options[fiber.Handler, fiber.Handler, gfiber.Route]{
-			Openapi:               openapi,
-			Context:               ctx,
+			Openapi: openapi,
+			Context: ctx,
 			JSONDocumentationPath: "/json/path",
 			YAMLDocumentationPath: "/yaml/path",
 		})
@@ -223,10 +219,8 @@ func TestFiberNewRouter(t *testing.T) {
 			yamlDocumentationPath: "/yaml/path",
 			hostRouters:           make(map[string]*Router[fiber.Handler, fiber.Handler, gfiber.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 
@@ -508,10 +502,8 @@ func TestGorillaNewRouter(t *testing.T) {
 			yamlDocumentationPath: DefaultYAMLDocumentationPath,
 			hostRouters:           make(map[string]*Router[gorilla.HandlerFunc, mux.MiddlewareFunc, gorilla.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 
@@ -532,10 +524,8 @@ func TestGorillaNewRouter(t *testing.T) {
 			yamlDocumentationPath: DefaultYAMLDocumentationPath,
 			hostRouters:           make(map[string]*Router[gorilla.HandlerFunc, mux.MiddlewareFunc, gorilla.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 
@@ -558,10 +548,8 @@ func TestGorillaNewRouter(t *testing.T) {
 			yamlDocumentationPath: "/yaml/path",
 			hostRouters:           make(map[string]*Router[gorilla.HandlerFunc, mux.MiddlewareFunc, gorilla.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 
@@ -680,7 +668,8 @@ func TestGorillaGenerateAndExposeSwagger(t *testing.T) {
 
 		err = router.GenerateAndExposeOpenapi()
 		require.Error(t, err)
-		require.True(t, strings.HasPrefix(err.Error(), fmt.Sprintf("%s:", ErrValidatingOAS)))
+		// Update the assertion to check for the correct error prefix
+		require.True(t, strings.HasPrefix(err.Error(), fmt.Sprintf("%s for root:", ErrValidatingOAS)))
 	})
 
 	t.Run("correctly expose json documentation from loaded openapi file", func(t *testing.T) {
@@ -1135,10 +1124,8 @@ func TestEchoNewRouter(t *testing.T) {
 			yamlDocumentationPath: DefaultYAMLDocumentationPath,
 			hostRouters:           make(map[string]*Router[echo.HandlerFunc, echo.MiddlewareFunc, gecho.Route]),
 			rootRouter:            nil, // This will be set below
-			defaultRouter:         nil, // This will be set below
 		}
 		expected.rootRouter = expected    // Set root reference to self
-		expected.defaultRouter = expected // Set default router to self
 		require.Equal(t, expected, r)
 	})
 }

--- a/operation.go
+++ b/operation.go
@@ -1,7 +1,9 @@
 package swagger
 
 import (
+	"fmt"
 	"github.com/getkin/kin-openapi/openapi3"
+	"strings"
 )
 
 // Operation wraps an OpenAPI 3.0 operation with additional helper methods.
@@ -9,6 +11,426 @@ import (
 // while maintaining compatibility with the underlying openapi3.Operation.
 type Operation struct {
 	*openapi3.Operation
+}
+
+type visitedRefs map[string]struct{}
+
+// ResolveReferences replaces all $ref references in the operation with their actual component
+// definitions from the root schema. Returns an error if any references cannot be resolved.
+func (o *Operation) ResolveReferences(rootSchema *openapi3.T) error {
+	if o == nil || o.Operation == nil {
+		return nil
+	}
+
+	visited := make(visitedRefs)
+	return o.resolveReferences(rootSchema, visited)
+}
+
+func (o *Operation) resolveReferences(rootSchema *openapi3.T, visited visitedRefs) error {
+	// Resolve top-level references first (breadth-first)
+	if err := o.resolveRequestBodyRefs(rootSchema, visited); err != nil {
+		return err
+	}
+
+	if err := o.resolveResponseRefs(rootSchema, visited); err != nil {
+		return err
+	}
+
+	return o.resolveParameterRefs(rootSchema, visited)
+}
+
+func (o *Operation) resolveRequestBodyRefs(rootSchema *openapi3.T, visited visitedRefs) error {
+	if o.RequestBody == nil {
+		return nil
+	}
+
+	if o.RequestBody.Ref != "" {
+		if _, exists := visited[o.RequestBody.Ref]; exists {
+			return nil // Already visited this reference
+		}
+		visited[o.RequestBody.Ref] = struct{}{}
+
+		resolved, err := resolveComponentRef(rootSchema, o.RequestBody.Ref, visited)
+		if err != nil {
+			return fmt.Errorf("requestBody: %w", err)
+		}
+		reqBody, ok := resolved.(*openapi3.RequestBody)
+		if !ok {
+			return fmt.Errorf("requestBody: expected *openapi3.RequestBody, got %T", resolved)
+		}
+		o.RequestBody.Value = reqBody
+	}
+
+	if o.RequestBody.Value != nil {
+		return resolveContentRefs(rootSchema, o.RequestBody.Value.Content, "requestBody", visited)
+	}
+
+	return nil
+}
+
+func (o *Operation) resolveResponseRefs(rootSchema *openapi3.T, visited visitedRefs) error {
+	if o.Responses == nil {
+		return nil
+	}
+	for status, respRef := range o.Responses.Map() {
+		if respRef.Ref != "" {
+			if _, exists := visited[respRef.Ref]; exists {
+				continue // Already visited this reference
+			}
+			visited[respRef.Ref] = struct{}{}
+
+			resolved, err := resolveComponentRef(rootSchema, respRef.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("response %s: %w", status, err)
+			}
+			resp, ok := resolved.(*openapi3.Response)
+			if !ok {
+				return fmt.Errorf("response %s: expected *openapi3.Response, got %T", status, resolved)
+			}
+			respRef.Value = resp
+		}
+
+		if respRef.Value != nil {
+			if err := resolveContentRefs(rootSchema, respRef.Value.Content, fmt.Sprintf("response %s", status), visited); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (o *Operation) resolveParameterRefs(rootSchema *openapi3.T, visited visitedRefs) error {
+	if o.Parameters == nil {
+		return nil
+	}
+	for _, paramRef := range o.Parameters {
+		if paramRef.Ref != "" {
+			if _, exists := visited[paramRef.Ref]; exists {
+				continue // Already visited this reference
+			}
+			visited[paramRef.Ref] = struct{}{}
+
+			resolved, err := resolveComponentRef(rootSchema, paramRef.Ref, visited)
+			if err != nil {
+				// If Value is nil, we can't get the name, so just use the ref
+				paramName := paramRef.Ref
+				if paramRef.Value != nil {
+					paramName = paramRef.Value.Name
+				}
+				return fmt.Errorf("parameter %q: %w", paramName, err)
+			}
+			param, ok := resolved.(*openapi3.Parameter)
+			if !ok {
+				paramName := paramRef.Ref
+				if paramRef.Value != nil {
+					paramName = paramRef.Value.Name
+				}
+				return fmt.Errorf("parameter %q: expected *openapi3.Parameter, got %T", paramName, resolved)
+			}
+			paramRef.Value = param
+		}
+
+		if paramRef.Value != nil {
+			if paramRef.Value.Content != nil {
+				if err := resolveContentRefs(rootSchema, paramRef.Value.Content, fmt.Sprintf("parameter %q", paramRef.Value.Name), visited); err != nil {
+					return err
+				}
+			}
+
+			if paramRef.Value.Schema != nil && paramRef.Value.Schema.Ref != "" {
+				if err := convertSchemaRefToStandardFormat(paramRef.Value.Schema, fmt.Sprintf("parameter %q", paramRef.Value.Name), ""); err != nil {
+					return err
+				}
+				if _, exists := visited[paramRef.Value.Schema.Ref]; exists {
+					continue // Already visited this reference
+				}
+				visited[paramRef.Value.Schema.Ref] = struct{}{}
+
+				resolved, err := resolveComponentRef(rootSchema, paramRef.Value.Schema.Ref, visited)
+				if err != nil {
+					return fmt.Errorf("parameter %q schema: %w", paramRef.Value.Name, err)
+				}
+				schema, ok := resolved.(*openapi3.Schema)
+				if !ok {
+					return fmt.Errorf("parameter %q schema: expected *openapi3.Schema, got %T", paramRef.Value.Name, resolved)
+				}
+				paramRef.Value.Schema.Value = schema
+				// Keep the converted Ref in the schema for documentation generation
+			}
+		}
+	}
+	return nil
+}
+
+// resolveContentRefs handles resolving references in Content maps consistently across all types
+func resolveContentRefs(rootSchema *openapi3.T, content openapi3.Content, context string, visited visitedRefs) error {
+	for mediaType, media := range content {
+		if media.Schema != nil && media.Schema.Ref != "" {
+			if err := convertSchemaRefToStandardFormat(media.Schema, context, mediaType); err != nil {
+				return err
+			}
+			if _, exists := visited[media.Schema.Ref]; exists {
+				continue // Already visited this reference
+			}
+			visited[media.Schema.Ref] = struct{}{}
+
+			resolved, err := resolveComponentRef(rootSchema, media.Schema.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("%s content %q schema: %w", context, mediaType, err)
+			}
+			media.Schema.Value = resolved.(*openapi3.Schema)
+			// Keep the converted Ref in the schema for documentation generation
+		}
+	}
+	return nil
+}
+
+// makeComponentRef creates a standard OpenAPI component reference path
+func makeComponentRef(componentName string) string {
+	return "#/components/schemas/" + componentName
+}
+
+// convertSchemaRefToStandardFormat converts a schema reference to standard OpenAPI format
+// and preserves the original reference by converting it to #/components/schemas/ format
+func convertSchemaRefToStandardFormat(schemaRef *openapi3.SchemaRef, context, mediaType string) error {
+	componentName := determineComponentName(schemaRef.Ref, "")
+	if componentName == "" {
+		return fmt.Errorf("%s content %q: could not determine component name from reference %q",
+			context, mediaType, schemaRef.Ref)
+	}
+
+	// Convert reference to standard OpenAPI format
+	schemaRef.Ref = makeComponentRef(componentName)
+	return nil
+}
+
+// processSchemaRefs recursively processes all references within a schema
+func processSchemaRefs(rootSchema *openapi3.T, schema *openapi3.Schema, visited visitedRefs) error {
+	// Process properties
+	for _, prop := range schema.Properties {
+		if prop.Ref != "" {
+			if _, exists := visited[prop.Ref]; exists {
+				continue // Skip already visited references to break cycles
+			}
+			visited[prop.Ref] = struct{}{}
+
+			if err := convertSchemaRefToStandardFormat(prop, "schema property", ""); err != nil {
+				return err
+			}
+			resolved, err := resolveComponentRef(rootSchema, prop.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("schema property %q: %w", prop.Ref, err)
+			}
+			prop.Value = resolved.(*openapi3.Schema)
+		}
+		if prop.Value != nil {
+			if err := processSchemaRefs(rootSchema, prop.Value, visited); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Process array items
+	if schema.Items != nil {
+		if schema.Items.Ref != "" {
+			if _, exists := visited[schema.Items.Ref]; exists {
+				return nil // Skip already visited references to break cycles
+			}
+			visited[schema.Items.Ref] = struct{}{}
+
+			if err := convertSchemaRefToStandardFormat(schema.Items, "schema items", ""); err != nil {
+				return err
+			}
+			resolved, err := resolveComponentRef(rootSchema, schema.Items.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("schema items: %w", err)
+			}
+			schema.Items.Value = resolved.(*openapi3.Schema)
+		}
+		if schema.Items.Value != nil {
+			if err := processSchemaRefs(rootSchema, schema.Items.Value, visited); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Process additional properties
+	if schema.AdditionalProperties.Schema != nil {
+		if schema.AdditionalProperties.Schema.Ref != "" {
+			if _, exists := visited[schema.AdditionalProperties.Schema.Ref]; exists {
+				return nil // Skip already visited references to break cycles
+			}
+			visited[schema.AdditionalProperties.Schema.Ref] = struct{}{}
+
+			if err := convertSchemaRefToStandardFormat(schema.AdditionalProperties.Schema, "schema additionalProperties", ""); err != nil {
+				return err
+			}
+			resolved, err := resolveComponentRef(rootSchema, schema.AdditionalProperties.Schema.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("schema additionalProperties: %w", err)
+			}
+			schema.AdditionalProperties.Schema.Value = resolved.(*openapi3.Schema)
+		}
+		if schema.AdditionalProperties.Schema.Value != nil {
+			if err := processSchemaRefs(rootSchema, schema.AdditionalProperties.Schema.Value, visited); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Process allOf/anyOf/oneOf
+	for i, s := range schema.AllOf {
+		if s.Ref != "" {
+			if _, exists := visited[s.Ref]; exists {
+				continue // Skip already visited references to break cycles
+			}
+			visited[s.Ref] = struct{}{}
+
+			if err := convertSchemaRefToStandardFormat(s, "schema allOf", ""); err != nil {
+				return err
+			}
+			resolved, err := resolveComponentRef(rootSchema, s.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("schema allOf[%d]: %w", i, err)
+			}
+			s.Value = resolved.(*openapi3.Schema)
+		}
+		if s.Value != nil {
+			if err := processSchemaRefs(rootSchema, s.Value, visited); err != nil {
+				return err
+			}
+		}
+	}
+	for i, s := range schema.AnyOf {
+		if s.Ref != "" {
+			if _, exists := visited[s.Ref]; exists {
+				continue // Skip already visited references to break cycles
+			}
+			visited[s.Ref] = struct{}{}
+
+			if err := convertSchemaRefToStandardFormat(s, "schema anyOf", ""); err != nil {
+				return err
+			}
+			resolved, err := resolveComponentRef(rootSchema, s.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("schema anyOf[%d]: %w", i, err)
+			}
+			s.Value = resolved.(*openapi3.Schema)
+		}
+		if s.Value != nil {
+			if err := processSchemaRefs(rootSchema, s.Value, visited); err != nil {
+				return err
+			}
+		}
+	}
+	for i, s := range schema.OneOf {
+		if s.Ref != "" {
+			if _, exists := visited[s.Ref]; exists {
+				continue // Skip already visited references to break cycles
+			}
+			visited[s.Ref] = struct{}{}
+
+			if err := convertSchemaRefToStandardFormat(s, "schema oneOf", ""); err != nil {
+				return err
+			}
+			resolved, err := resolveComponentRef(rootSchema, s.Ref, visited)
+			if err != nil {
+				return fmt.Errorf("schema oneOf[%d]: %w", i, err)
+			}
+			s.Value = resolved.(*openapi3.Schema)
+		}
+		if s.Value != nil {
+			if err := processSchemaRefs(rootSchema, s.Value, visited); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func resolveComponentRef(rootSchema *openapi3.T, ref string, visited visitedRefs) (interface{}, error) {
+	if !strings.HasPrefix(ref, "#/") {
+		return nil, fmt.Errorf("reference %q must point to a component", ref)
+	}
+
+	// Split reference into parts
+	parts := strings.Split(ref, "/")
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid reference format: %q", ref)
+	}
+
+	// Whitelist of allowed reference prefixes
+	allowedPrefixes := map[string]bool{
+		"components":  true,
+		"$defs":       true,
+		"definitions": true,
+	}
+
+	componentType := parts[1]
+	if !allowedPrefixes[componentType] {
+		return nil, fmt.Errorf("invalid reference format: %q", ref)
+	}
+
+	componentName := parts[2] // the actual component name
+
+	// Handle standard OpenAPI component references
+	if componentType == "components" && len(parts) >= 4 {
+		componentType = parts[2] // e.g. "schemas", "responses" etc.
+		componentName = parts[3]
+	} else if componentType == "$defs" || componentType == "definitions" {
+		// Handle jsonschema $defs and definitions references
+		componentType = "schemas" // Treat them as schemas
+	}
+
+	switch componentType {
+	case "schemas":
+		if rootSchema.Components == nil || rootSchema.Components.Schemas == nil {
+			return nil, fmt.Errorf("no schemas defined in components")
+		}
+		schema, exists := rootSchema.Components.Schemas[componentName]
+		if !exists {
+			return nil, fmt.Errorf("schema %q not found", componentName)
+		}
+
+		// Recursively resolve references within the schema itself
+		if schema.Value != nil {
+			if err := processSchemaRefs(rootSchema, schema.Value, visited); err != nil {
+				return nil, fmt.Errorf("failed to process schema refs for %q: %w", componentName, err)
+			}
+		}
+
+		return schema.Value, nil
+	case "responses":
+		if rootSchema.Components == nil || rootSchema.Components.Responses == nil {
+			return nil, fmt.Errorf("no responses defined in components")
+		}
+		response, exists := rootSchema.Components.Responses[componentName]
+		if !exists {
+			return nil, fmt.Errorf("response %q not found", componentName)
+		}
+		return response.Value, nil
+	case "parameters":
+		if rootSchema.Components == nil || rootSchema.Components.Parameters == nil {
+			return nil, fmt.Errorf("no parameters defined in components")
+		}
+		param, exists := rootSchema.Components.Parameters[componentName]
+		if !exists {
+			return nil, fmt.Errorf("parameter %q not found", componentName)
+		}
+		return param.Value, nil
+	case "requestBodies":
+		if rootSchema.Components == nil || rootSchema.Components.RequestBodies == nil {
+			return nil, fmt.Errorf("no requestBodies defined in components")
+		}
+		reqBody, exists := rootSchema.Components.RequestBodies[componentName]
+		if !exists {
+			return nil, fmt.Errorf("requestBody %q not found", componentName)
+		}
+		return reqBody.Value, nil
+	default:
+		return nil, fmt.Errorf("unsupported component type: %q", componentType)
+	}
 }
 
 // NewOperation creates and returns a new Operation instance.
@@ -36,9 +458,9 @@ func (o *Operation) AddRequestBody(requestBody *openapi3.RequestBody) {
 // Parameters:
 //   - status: HTTP status code (e.g. 200, 404)
 //   - response: OpenAPI response definition containing:
-//     - Description
-//     - Content types and schemas
-//     - Headers
+//   - Description
+//   - Content types and schemas
+//   - Headers
 func (o *Operation) AddResponse(status int, response *openapi3.Response) {
 	if o.Responses == nil {
 		o.Responses = &openapi3.Responses{}

--- a/operation_test.go
+++ b/operation_test.go
@@ -1,12 +1,56 @@
 package swagger
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 )
+
+func getBaseSwagger(t *testing.T) *openapi3.T {
+	t.Helper()
+
+	return &openapi3.T{
+		Info: &openapi3.Info{
+			Title:   "test openapi title",
+			Version: "test openapi version",
+		},
+	}
+}
+
+func getRootSchemaWithComponents(t *testing.T) *openapi3.T {
+	t.Helper()
+	return &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: map[string]*openapi3.SchemaRef{
+				"UserSchema":       {Value: openapi3.NewObjectSchema()},
+				"NestedSchema":     {Value: openapi3.NewIntegerSchema()},
+				"ParentSchema":     {Value: openapi3.NewObjectSchema().WithPropertyRef("nested", &openapi3.SchemaRef{Ref: "#/components/schemas/NestedSchema"})},
+				"ItemSchema":       {Value: openapi3.NewStringSchema()},
+				"AdditionalSchema": {Value: openapi3.NewBoolSchema()},
+				"AllOfSchema":      {Value: openapi3.NewFloat64Schema()},
+				"AnyOfSchema":      {Value: openapi3.NewInt32Schema()},
+				"OneOfSchema":      {Value: openapi3.NewInt64Schema()},
+				"MyDef":            {Value: openapi3.NewStringSchema()},  // For $defs and definitions tests
+				"AnotherDef":       {Value: openapi3.NewIntegerSchema()}, // For $defs and definitions tests
+			},
+			Responses: map[string]*openapi3.ResponseRef{
+				"NotFoundResponse": {Value: openapi3.NewResponse().WithDescription("Not Found")},
+				"TestResponse":     {Value: openapi3.NewResponse().WithDescription("Test Response")},
+			},
+			Parameters: map[string]*openapi3.ParameterRef{
+				"UserIdParameter": {Value: &openapi3.Parameter{Name: "userId", In: "path"}},
+				"TestParameter":   {Value: &openapi3.Parameter{Name: "testParam", In: "query"}},
+			},
+			RequestBodies: map[string]*openapi3.RequestBodyRef{
+				"UserRequestBody": {Value: openapi3.NewRequestBody()},
+				"TestRequestBody": {Value: openapi3.NewRequestBody().WithDescription("Test Body")},
+			},
+		},
+	}
+}
 
 func TestNewOperation(t *testing.T) {
 	schema := openapi3.NewObjectSchema().WithProperties(map[string]*openapi3.Schema{
@@ -52,5 +96,911 @@ func TestNewOperation(t *testing.T) {
 			jsonData := string(data)
 			require.JSONEq(t, test.expectedJSON, jsonData, "actual json data: %s", jsonData)
 		})
+	}
+}
+
+func TestResolveReferences(t *testing.T) {
+	t.Run("resolve references in request body", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/components/requestBodies/TestRequestBody"}
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		require.NotNil(t, op.RequestBody.Value)
+		require.Equal(t, "Test Body", op.RequestBody.Value.Description)
+		require.Equal(t, "#/components/requestBodies/TestRequestBody", op.RequestBody.Ref) // Ref should be kept
+	})
+
+	t.Run("resolve references in responses", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		op.Responses.Set("200", &openapi3.ResponseRef{Ref: "#/components/responses/TestResponse"})
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		respRef := op.Responses.Value("200")
+		require.NotNil(t, respRef)
+		require.NotNil(t, respRef.Value)
+		require.Equal(t, "Test Response", *respRef.Value.Description)
+		require.Equal(t, "#/components/responses/TestResponse", respRef.Ref) // Ref should be kept
+	})
+
+	t.Run("resolve references in parameters", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{Ref: "#/components/parameters/TestParameter"})
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		require.Len(t, op.Parameters, 1)
+		paramRef := op.Parameters[0]
+		require.NotNil(t, paramRef.Value)
+		require.Equal(t, "testParam", paramRef.Value.Name)
+		require.Equal(t, "query", paramRef.Value.In)
+		require.Equal(t, "#/components/parameters/TestParameter", paramRef.Ref) // Ref should be kept
+	})
+
+	t.Run("resolve references in content schemas", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		// Add the test schema to components
+		schema := openapi3.NewStringSchema()
+		schema.Description = "Test Schema"
+		registerTestSchema(rootSchema, "TestSchema", schema)
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{}
+		op.RequestBody.Value = openapi3.NewRequestBody()
+		op.RequestBody.Value.Content = openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/TestSchema"}),
+		}
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		mediaType := op.RequestBody.Value.Content["application/json"]
+		require.NotNil(t, mediaType)
+		require.NotNil(t, mediaType.Schema)
+		require.NotNil(t, mediaType.Schema.Value)
+		require.Equal(t, "Test Schema", mediaType.Schema.Value.Description)
+		require.Equal(t, "#/components/schemas/TestSchema", mediaType.Schema.Ref) // Ref should be converted to standard format and kept
+	})
+
+	t.Run("resolve references recursively in schemas", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		op.Responses.Set("200", &openapi3.ResponseRef{Value: openapi3.NewResponse().WithJSONSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/ParentSchema"})})
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		respRef := op.Responses.Value("200")
+		require.NotNil(t, respRef)
+		require.NotNil(t, respRef.Value)
+		require.NotNil(t, respRef.Value.Content["application/json"])
+		schemaRef := respRef.Value.Content["application/json"].Schema
+		require.NotNil(t, schemaRef)
+		require.NotNil(t, schemaRef.Value)
+		require.Equal(t, "#/components/schemas/ParentSchema", schemaRef.Ref) // Ref should be converted and kept
+
+		nestedSchemaRef := schemaRef.Value.Properties["nested"]
+		require.NotNil(t, nestedSchemaRef)
+		require.NotNil(t, nestedSchemaRef.Value)
+		require.Equal(t, "#/components/schemas/NestedSchema", nestedSchemaRef.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeInteger, nestedSchemaRef.Value.Type.Slice()[0])
+	})
+
+	t.Run("handle missing components", func(t *testing.T) {
+		rootSchema := &openapi3.T{} // No components defined
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/components/requestBodies/TestRequestBody"}
+
+		err := op.ResolveReferences(rootSchema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requestBody: no requestBodies defined in components")
+	})
+
+	t.Run("handle missing component definition", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				RequestBodies: map[string]*openapi3.RequestBodyRef{}, // Empty map
+			},
+		}
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/components/requestBodies/TestRequestBody"}
+
+		err := op.ResolveReferences(rootSchema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `requestBody: requestBody "TestRequestBody" not found`)
+	})
+
+	t.Run("handle invalid reference format", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/invalid"}
+
+		err := op.ResolveReferences(rootSchema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `requestBody: invalid reference format: "#/invalid"`)
+	})
+
+	t.Run("handle non-component reference", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "/some/path"}
+
+		err := op.ResolveReferences(rootSchema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `requestBody: reference "/some/path" must point to a component`)
+	})
+
+	t.Run("handle jsonschema $defs reference", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{}
+		op.RequestBody.Value = openapi3.NewRequestBody()
+		op.RequestBody.Value.Content = openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/$defs/MyDef"}),
+		}
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		mediaType := op.RequestBody.Value.Content["application/json"]
+		require.NotNil(t, mediaType)
+		require.NotNil(t, mediaType.Schema)
+		require.NotNil(t, mediaType.Schema.Value)
+		require.Equal(t, "#/components/schemas/MyDef", mediaType.Schema.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeString, mediaType.Schema.Value.Type.Slice()[0])
+	})
+
+	t.Run("handle jsonschema definitions reference", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{}
+		op.RequestBody.Value = openapi3.NewRequestBody()
+		op.RequestBody.Value.Content = openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/definitions/AnotherDef"}),
+		}
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		mediaType := op.RequestBody.Value.Content["application/json"]
+		require.NotNil(t, mediaType)
+		require.NotNil(t, mediaType.Schema)
+		require.NotNil(t, mediaType.Schema.Value)
+		require.Equal(t, "#/components/schemas/AnotherDef", mediaType.Schema.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeInteger, mediaType.Schema.Value.Type.Slice()[0])
+	})
+
+	t.Run("handle schema reference without component name", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{}
+		op.RequestBody.Value = openapi3.NewRequestBody()
+		op.RequestBody.Value.Content = openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/"}), // Invalid ref
+		}
+
+		err := op.ResolveReferences(rootSchema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `requestBody content "application/json": could not determine component name from reference "#/"`)
+	})
+}
+
+func TestMakeComponentRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		componentName string
+		expectedRef   string
+	}{
+		{"simple name", "User", "#/components/schemas/User"},
+		{"name with slash", "User/Profile", "#/components/schemas/User/Profile"},
+		{"empty name", "", "#/components/schemas/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualRef := makeComponentRef(tt.componentName)
+			require.Equal(t, tt.expectedRef, actualRef)
+		})
+	}
+}
+
+func TestConvertSchemaRefToStandardFormat(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputRef      string
+		expectedRef   string
+		expectError   bool
+		errorContains string
+	}{
+		{"standard components ref", "#/components/schemas/User", "#/components/schemas/User", false, ""},
+		{"jsonschema $defs ref", "#/$defs/Product", "#/components/schemas/Product", false, ""},
+		{"jsonschema definitions ref", "#/definitions/Order", "#/components/schemas/Order", false, ""},
+		{"local ref (treated as component)", "#/MyComponent", "#/components/schemas/MyComponent", false, ""},
+		{"invalid ref format", "#/", "", true, "could not determine component name from reference"},
+		{"empty ref", "", "", true, "could not determine component name from reference"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaRef := &openapi3.SchemaRef{Ref: tt.inputRef}
+			err := convertSchemaRefToStandardFormat(schemaRef, "test context", "application/json")
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedRef, schemaRef.Ref)
+			}
+		})
+	}
+}
+
+func TestProcessSchemaRefs(t *testing.T) {
+	t.Run("recursively resolves references in properties", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		parentSchema := openapi3.NewObjectSchema().WithPropertyRef("nested", &openapi3.SchemaRef{Ref: "#/components/schemas/NestedSchema"})
+
+		err := processSchemaRefs(rootSchema, parentSchema, make(visitedRefs))
+		require.NoError(t, err)
+
+		nestedSchemaRef := parentSchema.Properties["nested"]
+		require.NotNil(t, nestedSchemaRef)
+		require.NotNil(t, nestedSchemaRef.Value)
+		require.Equal(t, "#/components/schemas/NestedSchema", nestedSchemaRef.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeInteger, nestedSchemaRef.Value.Type.Slice()[0])
+	})
+
+	t.Run("recursively resolves references in array items", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		// Corrected: Create a new Schema and assign the SchemaRef to its Items field
+		arraySchema := openapi3.NewArraySchema()
+		arraySchema.Items = &openapi3.SchemaRef{Ref: "#/components/schemas/ItemSchema"}
+
+		err := processSchemaRefs(rootSchema, arraySchema, make(visitedRefs))
+		require.NoError(t, err)
+
+		itemSchemaRef := arraySchema.Items
+		require.NotNil(t, itemSchemaRef)
+		require.NotNil(t, itemSchemaRef.Value)
+		require.Equal(t, "#/components/schemas/ItemSchema", itemSchemaRef.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeString, itemSchemaRef.Value.Type.Slice()[0])
+	})
+
+	t.Run("recursively resolves references in additional properties", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		// Standard structure: SchemaRef directly in AdditionalProperties
+		objectSchema := openapi3.NewObjectSchema().WithAdditionalProperties(nil)
+		objectSchema.AdditionalProperties.Schema = openapi3.NewSchemaRef("#/components/schemas/AdditionalSchema", nil)
+
+		err := processSchemaRefs(rootSchema, objectSchema, make(visitedRefs))
+		require.NoError(t, err)
+
+		// Access the SchemaRef at the standard level
+		additionalSchemaRef := objectSchema.AdditionalProperties.Schema
+
+		require.NotNil(t, additionalSchemaRef)
+		require.NotNil(t, additionalSchemaRef.Value)
+		// Assert that the Ref is still the original reference string
+		require.Equal(t, "#/components/schemas/AdditionalSchema", additionalSchemaRef.Ref)
+		// Assert that the Value has been populated with the resolved schema
+		require.Equal(t, openapi3.TypeBoolean, additionalSchemaRef.Value.Type.Slice()[0])
+	})
+
+	t.Run("recursively resolves references in allOf", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		allOfSchema := openapi3.NewAllOfSchema()
+		allOfSchema.AllOf = append(allOfSchema.AllOf, &openapi3.SchemaRef{Ref: "#/components/schemas/AllOfSchema"})
+
+		err := processSchemaRefs(rootSchema, allOfSchema, make(visitedRefs))
+		require.NoError(t, err)
+
+		allOfRef := allOfSchema.AllOf[0]
+		require.NotNil(t, allOfRef)
+		require.NotNil(t, allOfRef.Value)
+		require.Equal(t, "#/components/schemas/AllOfSchema", allOfRef.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeNumber, allOfRef.Value.Type.Slice()[0])
+	})
+
+	t.Run("recursively resolves references in anyOf", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		anyOfSchema := openapi3.NewAnyOfSchema()
+		anyOfSchema.AnyOf = append(anyOfSchema.AnyOf, &openapi3.SchemaRef{Ref: "#/components/schemas/AnyOfSchema"})
+
+		err := processSchemaRefs(rootSchema, anyOfSchema, make(visitedRefs))
+		require.NoError(t, err)
+
+		anyOfRef := anyOfSchema.AnyOf[0]
+		require.NotNil(t, anyOfRef)
+		require.NotNil(t, anyOfRef.Value)
+		require.Equal(t, "#/components/schemas/AnyOfSchema", anyOfRef.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeInteger, anyOfRef.Value.Type.Slice()[0])
+		require.Equal(t, "int32", anyOfRef.Value.Format)
+	})
+
+	t.Run("recursively resolves references in oneOf", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		oneOfSchema := openapi3.NewOneOfSchema()
+		oneOfSchema.OneOf = append(oneOfSchema.OneOf, &openapi3.SchemaRef{Ref: "#/components/schemas/OneOfSchema"})
+
+		err := processSchemaRefs(rootSchema, oneOfSchema, make(visitedRefs))
+		require.NoError(t, err)
+
+		oneOfRef := oneOfSchema.OneOf[0]
+		require.NotNil(t, oneOfRef)
+		require.NotNil(t, oneOfRef.Value)
+		require.Equal(t, "#/components/schemas/OneOfSchema", oneOfRef.Ref) // Ref should be converted and kept
+		require.Equal(t, openapi3.TypeInteger, oneOfRef.Value.Type.Slice()[0])
+		require.Equal(t, "int64", oneOfRef.Value.Format)
+	})
+
+	t.Run("handle missing schema component during recursion", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Schemas: map[string]*openapi3.SchemaRef{}, // Empty map
+			},
+		}
+		parentSchema := openapi3.NewObjectSchema().WithPropertyRef("nested", &openapi3.SchemaRef{Ref: "#/components/schemas/MissingSchema"})
+
+		err := processSchemaRefs(rootSchema, parentSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `schema property "#/components/schemas/MissingSchema": schema "MissingSchema" not found`)
+	})
+}
+
+func TestResolveComponentRef(t *testing.T) {
+	rootSchema := getRootSchemaWithComponents(t)
+
+	tests := []struct {
+		name          string
+		ref           string
+		expectedType  string
+		expectError   bool
+		errorContains string
+	}{
+		{"schema ref", "#/components/schemas/UserSchema", "*openapi3.Schema", false, ""},
+		{"response ref", "#/components/responses/NotFoundResponse", "*openapi3.Response", false, ""},
+		{"parameter ref", "#/components/parameters/UserIdParameter", "*openapi3.Parameter", false, ""},
+		{"request body ref", "#/components/requestBodies/UserRequestBody", "*openapi3.RequestBody", false, ""},
+		{"jsonschema $defs ref", "#/$defs/UserSchema", "*openapi3.Schema", false, ""},
+		{"jsonschema definitions ref", "#/definitions/UserSchema", "*openapi3.Schema", false, ""},
+		{"missing schema", "#/components/schemas/MissingSchema", "", true, `schema "MissingSchema" not found`},
+		{"missing response", "#/components/responses/MissingResponse", "", true, `response "MissingResponse" not found`},
+		{"missing parameter", "#/components/parameters/MissingParameter", "", true, `parameter "MissingParameter" not found`},
+		{"missing request body", "#/components/requestBodies/MissingRequestBody", "", true, `requestBody "MissingRequestBody" not found`},
+		{"invalid component type", "#/components/invalid/MyComponent", "", true, `unsupported component type: "invalid"`},
+		{"invalid ref format", "#/components", "", true, "invalid reference format"},
+		{"non-component ref", "/some/path", "", true, `reference "/some/path" must point to a component`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, err := resolveComponentRef(rootSchema, tt.ref, make(visitedRefs))
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+				require.Nil(t, resolved)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resolved)
+				require.Equal(t, tt.expectedType, fmt.Sprintf("%T", resolved))
+			}
+		})
+	}
+}
+
+func TestResolveRequestBodyRefs(t *testing.T) {
+	t.Run("resolves request body reference", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		// Add the expected request body component
+		reqBody := openapi3.NewRequestBody()
+		reqBody.Description = "Test Body"
+		registerTestRequestBody(rootSchema, "TestBody", reqBody)
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/components/requestBodies/TestBody"}
+
+		err := op.resolveRequestBodyRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.NotNil(t, op.RequestBody.Value)
+		require.Equal(t, "Test Body", op.RequestBody.Value.Description)
+		require.Equal(t, "#/components/requestBodies/TestBody", op.RequestBody.Ref) // Ref should be kept
+	})
+
+	t.Run("handles nil request body", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = nil
+
+		err := op.resolveRequestBodyRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Nil(t, op.RequestBody)
+	})
+
+	t.Run("handles request body without reference", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Value: openapi3.NewRequestBody().WithDescription("Direct Body")}
+
+		err := op.resolveRequestBodyRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.NotNil(t, op.RequestBody.Value)
+		require.Equal(t, "Direct Body", op.RequestBody.Value.Description)
+		require.Empty(t, op.RequestBody.Ref) // Ref should remain empty if it was initially empty
+	})
+
+	t.Run("handles missing request body component", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				RequestBodies: map[string]*openapi3.RequestBodyRef{},
+			},
+		}
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/components/requestBodies/MissingBody"}
+
+		err := op.resolveRequestBodyRefs(rootSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `requestBody: requestBody "MissingBody" not found`)
+	})
+
+	t.Run("handles invalid request body reference format", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{Ref: "#/invalid/TestBody"}
+
+		err := op.resolveRequestBodyRefs(rootSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `requestBody: invalid reference format: "#/invalid/TestBody"`)
+	})
+
+	t.Run("resolves references within request body content", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		// Add the expected schema component
+		registerTestSchema(rootSchema, "TestSchema", openapi3.NewStringSchema())
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{
+			Value: openapi3.NewRequestBody().WithContent(openapi3.Content{
+				"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/TestSchema"}),
+			}),
+		}
+
+		err := op.resolveRequestBodyRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.NotNil(t, op.RequestBody.Value)
+		mediaType := op.RequestBody.Value.Content["application/json"]
+		require.NotNil(t, mediaType)
+		require.NotNil(t, mediaType.Schema)
+		require.NotNil(t, mediaType.Schema.Value)
+		require.Equal(t, openapi3.TypeString, mediaType.Schema.Value.Type.Slice()[0])
+		require.Equal(t, "#/components/schemas/TestSchema", mediaType.Schema.Ref) // Ref should be converted and kept
+	})
+}
+
+func TestResolveResponseRefs(t *testing.T) {
+	t.Run("resolves response reference", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		op.Responses.Set("200", &openapi3.ResponseRef{Ref: "#/components/responses/TestResponse"})
+
+		err := op.resolveResponseRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		respRef := op.Responses.Value("200")
+		require.NotNil(t, respRef)
+		require.NotNil(t, respRef.Value)
+		require.Equal(t, "Test Response", *respRef.Value.Description)
+		require.Equal(t, "#/components/responses/TestResponse", respRef.Ref) // Ref should be kept
+	})
+
+	t.Run("handles nil responses", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = nil
+
+		err := op.resolveResponseRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Nil(t, op.Responses)
+	})
+
+	t.Run("handles response without reference", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		op.Responses.Set("200", &openapi3.ResponseRef{Value: openapi3.NewResponse().WithDescription("Direct Response")})
+
+		err := op.resolveResponseRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		respRef := op.Responses.Value("200")
+		require.NotNil(t, respRef)
+		require.NotNil(t, respRef.Value)
+		require.Equal(t, "Direct Response", *respRef.Value.Description)
+		require.Empty(t, respRef.Ref) // Ref should remain empty if it was initially empty
+	})
+
+	t.Run("handles missing response component", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Responses: map[string]*openapi3.ResponseRef{},
+			},
+		}
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		op.Responses.Set("404", &openapi3.ResponseRef{Ref: "#/components/responses/MissingResponse"})
+
+		err := op.resolveResponseRefs(rootSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `response 404: response "MissingResponse" not found`)
+	})
+
+	t.Run("handles invalid response reference format", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		op.Responses.Set("500", &openapi3.ResponseRef{Ref: "#/invalid/TestResponse"})
+
+		err := op.resolveResponseRefs(rootSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `response 500: invalid reference format: "#/invalid/TestResponse"`)
+	})
+
+	t.Run("resolves references within response content", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		op := Operation{openapi3.NewOperation()}
+		op.Responses = openapi3.NewResponses()
+		registerTestSchema(rootSchema, "TestSchema", openapi3.NewStringSchema())
+
+		op.Responses.Set("200", &openapi3.ResponseRef{
+			Value: openapi3.NewResponse().WithDescription("").WithContent(openapi3.Content{
+				"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/TestSchema"}),
+			}),
+		})
+
+		err := op.resolveResponseRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		respRef := op.Responses.Value("200")
+		require.NotNil(t, respRef)
+		require.NotNil(t, respRef.Value)
+		mediaType := respRef.Value.Content["application/json"]
+		require.NotNil(t, mediaType)
+		require.NotNil(t, mediaType.Schema)
+		require.NotNil(t, mediaType.Schema.Value)
+		require.Equal(t, openapi3.TypeString, mediaType.Schema.Value.Type.Slice()[0])
+		require.Equal(t, "#/components/schemas/TestSchema", mediaType.Schema.Ref) // Ref should be converted and kept
+	})
+}
+
+func TestResolveParameterRefs(t *testing.T) {
+	t.Run("resolves parameter reference", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{Ref: "#/components/parameters/TestParameter"})
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Len(t, op.Parameters, 1)
+		paramRef := op.Parameters[0]
+		require.NotNil(t, paramRef.Value)
+		require.Equal(t, "testParam", paramRef.Value.Name)
+		require.Equal(t, "query", paramRef.Value.In)
+		require.Equal(t, "#/components/parameters/TestParameter", paramRef.Ref) // Ref should be kept
+	})
+
+	t.Run("handles nil parameters", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = nil
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Nil(t, op.Parameters)
+	})
+
+	t.Run("handles parameter without reference", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{Value: &openapi3.Parameter{Name: "directParam", In: "header"}})
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Len(t, op.Parameters, 1)
+		paramRef := op.Parameters[0]
+		require.NotNil(t, paramRef.Value)
+		require.Equal(t, "directParam", paramRef.Value.Name)
+		require.Equal(t, "header", paramRef.Value.In)
+		require.Empty(t, paramRef.Ref) // Ref should remain empty if it was initially empty
+	})
+
+	t.Run("handles missing parameter component", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Parameters: map[string]*openapi3.ParameterRef{},
+			},
+		}
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{Ref: "#/components/parameters/MissingParam"})
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `parameter "#/components/parameters/MissingParam": parameter "MissingParam" not found`)
+	})
+
+	t.Run("handles invalid parameter reference format", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Schemas: map[string]*openapi3.SchemaRef{}, // Empty map to trigger "no schemas" error
+			},
+		}
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{Ref: "#/invalid/TestParam"})
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `parameter "#/invalid/TestParam": invalid reference format: "#/invalid/TestParam"`)
+	})
+
+	t.Run("resolves references within parameter content", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		// Add TestSchema to components
+		registerTestSchema(rootSchema, "TestSchema", openapi3.NewStringSchema())
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{
+			Value: &openapi3.Parameter{
+				Name: "paramWithContent",
+				In:   "query",
+				Content: openapi3.Content{
+					"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/TestSchema"}),
+				},
+			},
+		})
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Len(t, op.Parameters, 1)
+		paramRef := op.Parameters[0]
+		require.NotNil(t, paramRef.Value)
+		mediaType := paramRef.Value.Content["application/json"]
+		require.NotNil(t, mediaType)
+		require.NotNil(t, mediaType.Schema)
+		require.NotNil(t, mediaType.Schema.Value)
+		require.Equal(t, openapi3.TypeString, mediaType.Schema.Value.Type.Slice()[0])
+		require.Equal(t, "#/components/schemas/TestSchema", mediaType.Schema.Ref) // Ref should be converted and kept
+	})
+
+	t.Run("resolves references within parameter schema", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		registerTestSchema(rootSchema, "TestSchema", openapi3.NewStringSchema())
+		op := Operation{openapi3.NewOperation()}
+		op.Parameters = openapi3.NewParameters()
+		op.Parameters = append(op.Parameters, &openapi3.ParameterRef{
+			Value: &openapi3.Parameter{
+				Name:   "paramWithSchema",
+				In:     "query",
+				Schema: &openapi3.SchemaRef{Ref: "#/components/schemas/TestSchema"},
+			},
+		})
+
+		err := op.resolveParameterRefs(rootSchema, make(visitedRefs))
+		require.NoError(t, err)
+		require.Len(t, op.Parameters, 1)
+		paramRef := op.Parameters[0]
+		require.NotNil(t, paramRef.Value)
+		require.NotNil(t, paramRef.Value.Schema)
+		require.NotNil(t, paramRef.Value.Schema.Value)
+		require.Equal(t, openapi3.TypeString, paramRef.Value.Schema.Value.Type.Slice()[0])
+		require.Equal(t, "#/components/schemas/TestSchema", paramRef.Value.Schema.Ref) // Ref should be converted and kept
+	})
+}
+
+func TestResolveContentRefs(t *testing.T) {
+	t.Run("resolves schema references in content", func(t *testing.T) {
+		rootSchema := getRootSchemaWithComponents(t)
+		registerTestSchema(rootSchema, "TestSchema", openapi3.NewStringSchema())
+		content := openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/TestSchema"}),
+			"text/plain":       openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/$defs/MyDef"}), // Test jsonschema ref
+		}
+
+		err := resolveContentRefs(rootSchema, content, "test context", make(visitedRefs))
+		require.NoError(t, err)
+
+		jsonMediaType := content["application/json"]
+		require.NotNil(t, jsonMediaType)
+		require.NotNil(t, jsonMediaType.Schema)
+		require.NotNil(t, jsonMediaType.Schema.Value)
+		require.Equal(t, openapi3.TypeString, jsonMediaType.Schema.Value.Type.Slice()[0])
+		require.Equal(t, "#/components/schemas/TestSchema", jsonMediaType.Schema.Ref) // Ref should be converted and kept
+
+		textMediaType := content["text/plain"]
+		require.NotNil(t, textMediaType)
+		require.NotNil(t, textMediaType.Schema)
+		require.NotNil(t, textMediaType.Schema.Value)
+		require.Equal(t, openapi3.TypeString, textMediaType.Schema.Value.Type.Slice()[0])
+		require.Equal(t, "#/components/schemas/MyDef", textMediaType.Schema.Ref) // Ref should be converted and kept
+	})
+
+	t.Run("handles content without schema references", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		content := openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchema(openapi3.NewObjectSchema()),
+		}
+
+		err := resolveContentRefs(rootSchema, content, "test context", make(visitedRefs))
+		require.NoError(t, err)
+		require.NotNil(t, content["application/json"].Schema.Value)
+		require.Empty(t, content["application/json"].Schema.Ref) // Ref should remain empty if it was initially empty
+	})
+
+	t.Run("handles missing schema component in content", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Schemas: map[string]*openapi3.SchemaRef{},
+			},
+		}
+		content := openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/components/schemas/MissingSchema"}),
+		}
+
+		err := resolveContentRefs(rootSchema, content, "test context", make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `test context content "application/json" schema: schema "MissingSchema" not found`)
+	})
+
+	t.Run("handles invalid schema reference format in content", func(t *testing.T) {
+		rootSchema := &openapi3.T{}
+		content := openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(&openapi3.SchemaRef{Ref: "#/"}),
+		}
+
+		err := resolveContentRefs(rootSchema, content, "test context", make(visitedRefs))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `test context content "application/json": could not determine component name from reference "#/"`)
+	})
+}
+
+func TestResolveReferences_CircularReferences(t *testing.T) {
+	t.Run("handle circular schema references", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Schemas: map[string]*openapi3.SchemaRef{
+					"PersonSchema": {
+						Value: openapi3.NewObjectSchema().WithPropertyRef("spouse",
+							&openapi3.SchemaRef{Ref: "#/components/schemas/PersonSchema"}),
+					},
+				},
+			},
+		}
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{}
+		op.RequestBody.Value = openapi3.NewRequestBody()
+		op.RequestBody.Value.Content = openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(
+				&openapi3.SchemaRef{Ref: "#/components/schemas/PersonSchema"}),
+		}
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err) // Should not hang or error with cycle detection
+
+		// Verify the circular reference is handled gracefully
+		mediaType := op.RequestBody.Value.Content["application/json"]
+		require.NotNil(t, mediaType.Schema.Value)
+		require.NotNil(t, mediaType.Schema.Value.Properties["spouse"])
+		require.Equal(t, "#/components/schemas/PersonSchema", mediaType.Schema.Value.Properties["spouse"].Ref)
+	})
+
+	t.Run("handle indirect circular references", func(t *testing.T) {
+		rootSchema := &openapi3.T{
+			Components: &openapi3.Components{
+				Schemas: map[string]*openapi3.SchemaRef{
+					"ParentSchema": {
+						Value: openapi3.NewObjectSchema().WithPropertyRef("child",
+							&openapi3.SchemaRef{Ref: "#/components/schemas/ChildSchema"}),
+					},
+					"ChildSchema": {
+						Value: openapi3.NewObjectSchema().WithPropertyRef("parent",
+							&openapi3.SchemaRef{Ref: "#/components/schemas/ParentSchema"}),
+					},
+				},
+			},
+		}
+
+		op := Operation{openapi3.NewOperation()}
+		op.RequestBody = &openapi3.RequestBodyRef{}
+		op.RequestBody.Value = openapi3.NewRequestBody()
+		op.RequestBody.Value.Content = openapi3.Content{
+			"application/json": openapi3.NewMediaType().WithSchemaRef(
+				&openapi3.SchemaRef{Ref: "#/components/schemas/ParentSchema"}),
+		}
+
+		err := op.ResolveReferences(rootSchema)
+		require.NoError(t, err)
+
+		mediaType := op.RequestBody.Value.Content["application/json"]
+		require.NotNil(t, mediaType.Schema.Value)
+		childRef := mediaType.Schema.Value.Properties["child"]
+		require.NotNil(t, childRef)
+		require.NotNil(t, childRef.Value)
+		require.Equal(t, "#/components/schemas/ChildSchema", childRef.Ref)
+		require.NotNil(t, childRef.Value.Properties["parent"])
+		require.Equal(t, "#/components/schemas/ParentSchema", childRef.Value.Properties["parent"].Ref)
+	})
+}
+
+func TestDetermineComponentName(t *testing.T) {
+	tests := []struct {
+		name         string
+		ref          string
+		inputName    string
+		expectedName string
+	}{
+		{"standard components ref", "#/components/schemas/User", "User", "User"},
+		{"jsonschema $defs ref", "#/$defs/Product", "Product", "Product"},
+		{"jsonschema definitions ref", "#/definitions/Order", "Order", "Order"},
+		{"local ref (treated as component)", "#/MyComponent", "MyComponent", "MyComponent"},
+		{"ref with slash", "#/components/schemas/User/Profile", "User/Profile", "User/Profile"},
+		{"empty ref, with name", "", "FallbackName", "FallbackName"},
+		{"empty ref, empty name", "", "", ""},
+		{"invalid ref format", "#/", "Invalid", ""}, // Should return empty string as name cannot be determined
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualName := determineComponentName(tt.ref, tt.inputName)
+			require.Equal(t, tt.expectedName, actualName)
+		})
+	}
+}
+
+// registerTestSchema adds a schema to the root schema's components for testing
+func registerTestSchema(rootSchema *openapi3.T, name string, schema *openapi3.Schema) {
+	if rootSchema.Components == nil {
+		rootSchema.Components = &openapi3.Components{}
+	}
+	if rootSchema.Components.Schemas == nil {
+		rootSchema.Components.Schemas = make(map[string]*openapi3.SchemaRef)
+	}
+	rootSchema.Components.Schemas[name] = &openapi3.SchemaRef{
+		Value: schema,
+	}
+}
+
+// registerTestRequestBody adds a request body to the root schema's components for testing
+func registerTestRequestBody(rootSchema *openapi3.T, name string, requestBody *openapi3.RequestBody) {
+	if rootSchema.Components == nil {
+		rootSchema.Components = &openapi3.Components{}
+	}
+	if rootSchema.Components.RequestBodies == nil {
+		rootSchema.Components.RequestBodies = make(map[string]*openapi3.RequestBodyRef)
+	}
+	rootSchema.Components.RequestBodies[name] = &openapi3.RequestBodyRef{
+		Value: requestBody,
 	}
 }

--- a/support/testutils/testutils.go
+++ b/support/testutils/testutils.go
@@ -8,25 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// AssertJSONMatchesFile reads a JSON file and compares its content with the provided byte slice.
+// It unmarshals both into generic Go types (map[string]interface{}) and uses require.Equal
+// for an order-insensitive comparison.
 func AssertJSONMatchesFile(t *testing.T, actual []byte, filename string) {
 	t.Helper()
-	
+
 	expected, err := os.ReadFile(filename)
 	require.NoError(t, err)
-	
+
 	var expectedJSON, actualJSON interface{}
-	
+
 	err = json.Unmarshal(expected, &expectedJSON)
 	require.NoError(t, err)
-	
+
 	err = json.Unmarshal(actual, &actualJSON)
 	require.NoError(t, err)
-	
-	expectedFormatted, err := json.MarshalIndent(expectedJSON, "", "  ")
-	require.NoError(t, err)
-	
-	actualFormatted, err := json.MarshalIndent(actualJSON, "", "  ")
-	require.NoError(t, err)
-	
-	require.Equal(t, string(expectedFormatted), string(actualFormatted))
+
+	// Use require.Equal for deep comparison of the unmarshaled structures
+	require.Equal(t, expectedJSON, actualJSON, "JSON mismatch with file %s", filename)
 }

--- a/testdata/multipart-requestbody.json
+++ b/testdata/multipart-requestbody.json
@@ -1,4 +1,31 @@
 {
+  "components": {
+    "schemas": {
+      "FormData": {
+        "properties": {
+          "address": {
+            "properties": {
+              "city": {
+                "type": "string"
+              },
+              "street": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "profileImage": {
+            "format": "binary",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
   "info": {
     "title": "test openapi title",
     "version": "test openapi version"
@@ -8,45 +35,25 @@
     "/files": {
       "post": {
         "requestBody": {
-          "description": "upload file",
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "address": {
-                    "type": "object",
-                    "properties": {
-                      "street": {
-                        "type": "string"
-                      },
-                      "city": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "profileImage": {
-                    "type": "string",
-                    "format": "binary"
-                  }
-                }
+                "$ref": "#/components/schemas/FormData"
               }
             }
-          }
+          },
+          "description": "upload file"
         },
         "responses": {
           "200": {
-            "description": "",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "string"
                 }
               }
-            }
+            },
+            "description": ""
           }
         }
       }

--- a/testdata/oneOf.json
+++ b/testdata/oneOf.json
@@ -1,4 +1,45 @@
 {
+  "components": {
+    "schemas": {
+      "UserProfileRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "firstName": {
+            "title": "user first name",
+            "type": "string"
+          },
+          "lastName": {
+            "title": "user last name",
+            "type": "string"
+          },
+          "metadata": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "custom properties"
+          },
+          "userType": {
+            "enum": [
+              "simple",
+              "advanced"
+            ],
+            "title": "type of user",
+            "type": "string"
+          }
+        },
+        "required": [
+          "firstName",
+          "lastName"
+        ],
+        "type": "object"
+      }
+    }
+  },
   "info": {
     "title": "test openapi title",
     "version": "test openapi version"
@@ -58,38 +99,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": false,
-                "properties": {
-                  "firstName": {
-                    "title": "user first name",
-                    "type": "string"
-                  },
-                  "lastName": {
-                    "title": "user last name",
-                    "type": "string"
-                  },
-                  "metadata": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "number"
-                      }
-                    ],
-                    "title": "custom properties"
-                  },
-                  "userType": {
-                    "title": "type of user",
-                    "type": "string",
-                    "enum": ["simple", "advanced"]
-                  }
-                },
-                "required": [
-                  "firstName",
-                  "lastName"
-                ],
-                "type": "object"
+                "$ref": "#/components/schemas/UserProfileRequest"
               }
             }
           }

--- a/testdata/schema-content-param.json
+++ b/testdata/schema-content-param.json
@@ -1,4 +1,20 @@
 {
+  "components": {
+    "schemas": {
+      "ParamContent": {
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      }
+    }
+  },
   "info": {
     "title": "test openapi title",
     "version": "test openapi version"
@@ -12,16 +28,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "value"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/ParamContent"
                 }
               }
             },

--- a/testdata/schema-no-content.json
+++ b/testdata/schema-no-content.json
@@ -12,30 +12,51 @@
             "in": "path",
             "name": "id",
             "required": true,
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "in": "query",
             "name": "q",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "in": "header",
             "name": "key",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "in": "cookie",
             "name": "cookie1",
-            "schema": {}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "content": {},
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
           "description": "request body without schema"
         },
         "responses": {
           "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "description": ""
           }
         }

--- a/testdata/users_employees.json
+++ b/testdata/users_employees.json
@@ -1,4 +1,76 @@
 {
+  "components": {
+    "schemas": {
+      "Employees": {
+        "additionalProperties": false,
+        "properties": {
+          "organization_name": {
+            "type": "string"
+          },
+          "users": {
+            "$ref": "#/components/schemas/Users"
+          }
+        },
+        "required": [
+          "organization_name",
+          "users"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "additionalProperties": false,
+        "properties": {
+          "address": {
+            "title": "user address",
+            "type": "string"
+          },
+          "groups": {
+            "default": [
+              "users"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "title": "groups of the user",
+            "type": "array"
+          },
+          "name": {
+            "example": "Jane",
+            "title": "The user name",
+            "type": "string"
+          },
+          "phone": {
+            "title": "mobile number of user",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "phone",
+          "address"
+        ],
+        "type": "object"
+      },
+      "Users": {
+        "items": {
+          "$ref": "#/components/schemas/User"
+        },
+        "type": "array"
+      },
+      "errorResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      }
+    }
+  },
   "info": {
     "title": "test openapi title",
     "version": "test openapi version"
@@ -12,54 +84,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "organization_name": {
-                      "type": "string"
-                    },
-                    "users": {
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "address": {
-                            "title": "user address",
-                            "type": "string"
-                          },
-                          "groups": {
-                            "default": [
-                              "users"
-                            ],
-                            "items": {
-                              "type": "string"
-                            },
-                            "title": "groups of the user",
-                            "type": "array"
-                          },
-                          "name": {
-                            "example": "Jane",
-                            "title": "The user name",
-                            "type": "string"
-                          },
-                          "phone": {
-                            "title": "mobile number of user",
-                            "type": "integer"
-                          }
-                        },
-                        "required": [
-                          "name",
-                          "phone",
-                          "address"
-                        ],
-                        "type": "object"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "required": [
-                    "organization_name",
-                    "users"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/Employees"
                 }
               }
             },
@@ -75,41 +100,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "address": {
-                        "title": "user address",
-                        "type": "string"
-                      },
-                      "groups": {
-                        "default": [
-                          "users"
-                        ],
-                        "items": {
-                          "type": "string"
-                        },
-                        "title": "groups of the user",
-                        "type": "array"
-                      },
-                      "name": {
-                        "example": "Jane",
-                        "title": "The user name",
-                        "type": "string"
-                      },
-                      "phone": {
-                        "title": "mobile number of user",
-                        "type": "integer"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "phone",
-                      "address"
-                    ],
-                    "type": "object"
-                  },
-                  "type": "array"
+                  "$ref": "#/components/schemas/Users"
                 }
               }
             },
@@ -122,38 +113,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": false,
-                "properties": {
-                  "address": {
-                    "title": "user address",
-                    "type": "string"
-                  },
-                  "groups": {
-                    "default": [
-                      "users"
-                    ],
-                    "items": {
-                      "type": "string"
-                    },
-                    "title": "groups of the user",
-                    "type": "array"
-                  },
-                  "name": {
-                    "example": "Jane",
-                    "title": "The user name",
-                    "type": "string"
-                  },
-                  "phone": {
-                    "title": "mobile number of user",
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "name",
-                  "phone",
-                  "address"
-                ],
-                "type": "object"
+                "$ref": "#/components/schemas/User"
               }
             }
           }
@@ -173,16 +133,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/errorResponse"
                 }
               }
             },

--- a/testdata/users_employees.yaml
+++ b/testdata/users_employees.yaml
@@ -1,3 +1,53 @@
+components:
+  schemas:
+    Employees:
+      additionalProperties: false
+      properties:
+        organization_name:
+          type: string
+        users:
+          $ref: '#/components/schemas/Users'
+      required:
+      - organization_name
+      - users
+      type: object
+    User:
+      additionalProperties: false
+      properties:
+        address:
+          title: user address
+          type: string
+        groups:
+          default:
+          - users
+          items:
+            type: string
+          title: groups of the user
+          type: array
+        name:
+          example: Jane
+          title: The user name
+          type: string
+        phone:
+          title: mobile number of user
+          type: integer
+      required:
+      - name
+      - phone
+      - address
+      type: object
+    Users:
+      items:
+        $ref: '#/components/schemas/User'
+      type: array
+    errorResponse:
+      additionalProperties: false
+      properties:
+        message:
+          type: string
+      required:
+      - message
+      type: object
 info:
   title: test openapi title
   version: test openapi version
@@ -6,125 +56,37 @@ paths:
   /employees:
     get:
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                additionalProperties: false
-                properties:
-                  organization_name:
-                    type: string
-                  users:
-                    items:
-                      additionalProperties: false
-                      properties:
-                        address:
-                          title: user address
-                          type: string
-                        groups:
-                          default:
-                            - users
-                          items:
-                            type: string
-                          title: groups of the user
-                          type: array
-                        name:
-                          example: Jane
-                          title: The user name
-                          type: string
-                        phone:
-                          title: mobile number of user
-                          type: integer
-                      required:
-                        - name
-                        - phone
-                        - address
-                      type: object
-                    type: array
-                required:
-                  - organization_name
-                  - users
-                type: object
-          description: ''
+                $ref: '#/components/schemas/Employees'
+          description: ""
   /users:
     get:
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                items:
-                  additionalProperties: false
-                  properties:
-                    address:
-                      title: user address
-                      type: string
-                    groups:
-                      default:
-                        - users
-                      items:
-                        type: string
-                      title: groups of the user
-                      type: array
-                    name:
-                      example: Jane
-                      title: The user name
-                      type: string
-                    phone:
-                      title: mobile number of user
-                      type: integer
-                  required:
-                    - name
-                    - phone
-                    - address
-                  type: object
-                type: array
-          description: ''
+                $ref: '#/components/schemas/Users'
+          description: ""
     post:
       requestBody:
         content:
           application/json:
             schema:
-              additionalProperties: false
-              properties:
-                address:
-                  title: user address
-                  type: string
-                groups:
-                  default:
-                    - users
-                  items:
-                    type: string
-                  title: groups of the user
-                  type: array
-                name:
-                  example: Jane
-                  title: The user name
-                  type: string
-                phone:
-                  title: mobile number of user
-                  type: integer
-              required:
-                - name
-                - phone
-                - address
-              type: object
+              $ref: '#/components/schemas/User'
       responses:
-        '201':
+        "201":
           content:
             text/html:
               schema:
                 type: string
-          description: ''
-        '401':
+          description: ""
+        "401":
           content:
             application/json:
               schema:
-                additionalProperties: false
-                properties:
-                  message:
-                    type: string
-                required:
-                  - message
-                type: object
+                $ref: '#/components/schemas/errorResponse'
           description: invalid request


### PR DESCRIPTION
- Removed defaultRouter field and simplified router hierarchy logic
- Enhanced schema reference resolution with proper component naming
- Added support for jsonschema $defs and definitions references
- Improved parameter handling with consistent ordering
- Added recursive schema reference processing
- Simplified host router and group router schema sharing
- Fixed documentation path handling with path prefixes
- Added comprehensive tests for reference resolution
- Improved JSON schema generation with proper component references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced OpenAPI handling with automatic resolution of all component references, supporting reusable schema components and improved error messages.
- **Refactor**
  - Unified and streamlined router logic for consistent schema sharing and documentation route handling.
  - Refactored parameter and schema extraction for routes, enabling robust and predictable OpenAPI generation.
  - Updated OpenAPI specs to use reusable component schemas, reducing duplication and simplifying maintenance.
  - Improved JSON schema reflection to extract and reference component schemas correctly.
- **Bug Fixes**
  - Improved matching and handling of documentation paths for routers with prefixes.
- **Tests**
  - Added comprehensive tests for OpenAPI reference resolution, including recursive and circular references.
  - Enhanced test robustness and clarity for route and schema logic.
- **Documentation**
  - Clarified and standardized OpenAPI example files for better readability and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->