### PR TITLE
refactor: add group flag to Router interface

### DIFF
--- a/apirouter/router.go
+++ b/apirouter/router.go
@@ -6,7 +6,7 @@ type Router[HandlerFunc any, MiddlewareFunc any, Route any] interface {
 	AddRoute(method string, path string, handler HandlerFunc, middleware ...MiddlewareFunc) Route
 	SwaggerHandler(contentType string, blob []byte) HandlerFunc
 	TransformPathToOasPath(path string) string
-	Router() any
+	Router(group bool) any
 	Group(pathPrefix string) Router[HandlerFunc, MiddlewareFunc, Route]
 	Host(host string) Router[HandlerFunc, MiddlewareFunc, Route]
 	Use(middleware ...MiddlewareFunc)

--- a/main.go
+++ b/main.go
@@ -21,11 +21,11 @@ var (
 )
 
 func GetRouter[T any, H any, M any, R any](r apirouter.Router[H, M, R]) T {
-	if r == nil || r.Router() == nil {
+	if r == nil || r.Router(true) == nil {
 		var zero T
 		return zero // Return zero value for the type T
 	}
-	return r.Router().(T)
+	return r.Router(true).(T)
 }
 
 const (
@@ -290,7 +290,7 @@ func NewRouter[HandlerFunc, MiddlewareFunc, Route any](frameworkRouter apirouter
 // ServeHTTP handles HTTP requests with the following precedence:
 // 1. Checks for swagger documentation requests
 // 2. Calls customServeHTTPHandler if set
-// 3. Attempts host-specific routing if available  
+// 3. Attempts host-specific routing if available
 // 4. Falls back to root router
 // Returns 500 if called on non-root router
 func (r *Router[HandlerFunc, MiddlewareFunc, Route]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -314,7 +314,7 @@ func (r *Router[HandlerFunc, MiddlewareFunc, Route]) ServeHTTP(w http.ResponseWr
 	expectedJSONDocPath := strings.TrimPrefix(targetRouter.jsonDocumentationPath, targetRouter.pathPrefix)
 	expectedYAMLDocPath := strings.TrimPrefix(targetRouter.yamlDocumentationPath, targetRouter.pathPrefix)
 	if req.URL.Path == expectedJSONDocPath || req.URL.Path == expectedYAMLDocPath {
-		if handler, ok := targetRouter.router.Router().(http.Handler); ok {
+		if handler, ok := targetRouter.router.Router(true).(http.Handler); ok {
 			handler.ServeHTTP(w, req)
 			return
 		}
@@ -330,14 +330,14 @@ func (r *Router[HandlerFunc, MiddlewareFunc, Route]) ServeHTTP(w http.ResponseWr
 
 	// Try host router first if available
 	if targetRouter != r {
-		if handler, ok := targetRouter.router.Router().(http.Handler); ok {
+		if handler, ok := targetRouter.router.Router(true).(http.Handler); ok {
 			handler.ServeHTTP(w, req)
 			return
 		}
 	}
 
 	// Fall back to root router
-	if handler, ok := r.router.Router().(http.Handler); ok {
+	if handler, ok := r.router.Router(true).(http.Handler); ok {
 		handler.ServeHTTP(w, req)
 		return
 	}

--- a/support/echo/echo.go
+++ b/support/echo/echo.go
@@ -43,8 +43,8 @@ func (r echoRouter) TransformPathToOasPath(path string) string {
 	return apirouter.TransformPathParamsWithColon(path)
 }
 
-func (r echoRouter) Router() any {
-	if r.group != nil {
+func (r echoRouter) Router(group bool) any {
+	if r.group != nil && group {
 		return r.group
 	}
 	return r.router


### PR DESCRIPTION
- Modified Router interface to include a boolean group parameter in Router() method
- Updated implementations in echo and main router to handle group routing properly
- Changed ServeHTTP logic to use group-aware routing when needed

This change allows better control over whether to return the group router or main router instance when getting the underlying router implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the router interface and related methods to require a boolean parameter, providing more explicit control over router selection.
  - Adjusted internal logic to ensure consistent use of the new method signature across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->