### PR TITLE
fix: clean up array schema definitions and unify router interface

### DIFF
--- a/route.go
+++ b/route.go
@@ -416,6 +416,10 @@ func (r Router[_, _, _]) getSchemaFromInterface(v interface{}, allowAdditionalPr
 		}
 	}
 
+	if jsonSchema.Type == "array" && jsonSchema.Definitions != nil {
+		jsonSchema.Definitions = nil
+	}
+
 	// Check if the reflected schema has a $ref
 	if jsonSchema.Ref != "" {
 		return openapi3.NewSchemaRef(jsonSchema.Ref, nil), nil

--- a/support/fiber/fiber.go
+++ b/support/fiber/fiber.go
@@ -15,7 +15,7 @@ type fiberRouter struct {
 	router fiber.Router // Can be *fiber.App or fiber.Router (from Group)
 }
 
-func (r fiberRouter) Router() any {
+func (r fiberRouter) Router(_ bool) any {
 	return r.router
 }
 

--- a/support/gorilla/gorilla.go
+++ b/support/gorilla/gorilla.go
@@ -52,7 +52,7 @@ func (r gorillaRouter) TransformPathToOasPath(path string) string {
 	return path
 }
 
-func (r gorillaRouter) Router() any {
+func (r gorillaRouter) Router(_ bool) any {
 	return r.router
 }
 


### PR DESCRIPTION
- Remove definitions from array type schemas in route.go to prevent invalid OpenAPI schemas
- Standardize Router() method signature across fiber and gorilla implementations to match interface by adding unused bool parameter (matching echo implementation)