### PR TITLE
refactor: normalize host by adding default ports in ServeHTTP

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"path"
 	"strings"
@@ -329,6 +330,17 @@ func (r *Router[HandlerFunc, MiddlewareFunc, Route]) ServeHTTP(w http.ResponseWr
 
 	// First check if this is a swagger documentation request
 	host := req.Host
+	
+	// Normalize host by adding default port when missing (IPv6-safe, proxy-aware)
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		// Missing port or not in host:port form
+		defaultPort := "80"
+		if req.TLS != nil || strings.EqualFold(req.Header.Get("X-Forwarded-Proto"), "https") {
+			defaultPort = "443"
+		}
+		host = host + ":" + defaultPort
+	}
+
 	var targetRouter *Router[HandlerFunc, MiddlewareFunc, Route]
 
 	// Select host router if exists, otherwise use root router


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host-based routing by normalizing incoming requests that omit an explicit port: the server now assumes port 443 for secure (TLS/HTTPS) connections and port 80 for non-secure connections. This prevents routing mismatches when clients omit ports and improves reliability across environments. No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->