### PR TITLE
feat(core): add GetPathPrefix method to Router

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,8 @@ type Router[HandlerFunc any, MiddlewareFunc any, Route any] struct {
 
 	host string
 
+
+
 	rootRouter *Router[HandlerFunc, MiddlewareFunc, Route]
 
 	hostRouters map[string]*Router[HandlerFunc, MiddlewareFunc, Route]
@@ -161,6 +163,12 @@ func (r *Router[HandlerFunc, MiddlewareFunc, Route]) Group(pathPrefix string) (*
 		reflectorOptions:      r.reflectorOptions,                  // Share reflector options
 		isSubrouter:           true,
 	}, nil
+}
+
+// GetPathPrefix returns the accumulated path prefix for this router.
+// For grouped routers, this includes all parent prefixes joined together.
+func (r *Router[HandlerFunc, MiddlewareFunc, Route]) GetPathPrefix() string {
+	return r.pathPrefix
 }
 
 // Host creates a new router instance configured for a specific host.


### PR DESCRIPTION
- Add GetPathPrefix() method that returns the accumulated path prefix for this router, including all parent prefixes for grouped routers.

---

<!-- kody-pr-summary:start -->
Add `GetPathPrefix` method to Router to expose the accumulated path prefix

This PR adds a public `GetPathPrefix()` method to the `Router` struct, allowing consumers to retrieve the accumulated path prefix for a given router instance. For grouped routers, this includes all parent prefixes joined together, providing visibility into the full path prefix that was built up through nested `Group()` calls.
<!-- kody-pr-summary:end -->