### PR TITLE
fix: strip JSON Schema-only fields for OpenAPI 3.0 compatibility

### DIFF
--- a/route.go
+++ b/route.go
@@ -504,7 +504,7 @@ func (r Router[_, _, _]) checkForCycles(v any, path []typeTrace) error {
 			}
 			trace.WriteString("\n")
 
-			return fmt.Errorf(trace.String())
+			return errors.New(trace.String())
 		}
 	}
 
@@ -605,6 +605,29 @@ func (r Router[_, _, _]) checkForCycles(v any, path []typeTrace) error {
 	return nil
 }
 
+func stripJSONSchemaOnlyFields(v any) {
+	switch m := v.(type) {
+	case map[string]any:
+		// contentEncoding: "base64" → format: byte (OpenAPI 3.0 equivalent)
+		if enc, ok := m["contentEncoding"]; ok {
+			if encStr, ok := enc.(string); ok && encStr == "base64" {
+				m["format"] = "byte"
+			}
+			delete(m, "contentEncoding")
+		}
+		delete(m, "contentMediaType")
+		delete(m, "contentSchema")
+		delete(m, "$defs")
+		for _, v2 := range m {
+			stripJSONSchemaOnlyFields(v2)
+		}
+	case []any:
+		for _, v2 := range m {
+			stripJSONSchemaOnlyFields(v2)
+		}
+	}
+}
+
 func (r Router[_, _, _]) getSchemaFromInterface(v any, allowAdditionalProperties bool) (*openapi3.SchemaRef, error) {
 	if v == nil {
 		return &openapi3.SchemaRef{}, nil
@@ -675,6 +698,17 @@ func (r Router[_, _, _]) getSchemaFromInterface(v any, allowAdditionalProperties
 				return nil, fmt.Errorf("failed to marshal jsonschema definition %q: %w", name, err)
 			}
 
+			// Strip JSON Schema-only fields for OpenAPI 3.0 compatibility
+			var defMap map[string]any
+			if err := json.Unmarshal(defData, &defMap); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal definition %q into map: %w", name, err)
+			}
+			stripJSONSchemaOnlyFields(defMap)
+			defData, err = json.Marshal(defMap)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal cleaned definition %q: %w", name, err)
+			}
+
 			// Unmarshal the JSON definition into an openapi3.Schema
 			oasSchema := openapi3.NewSchema()
 			if err := oasSchema.UnmarshalJSON(defData); err != nil {
@@ -691,7 +725,7 @@ func (r Router[_, _, _]) getSchemaFromInterface(v any, allowAdditionalProperties
 		}
 	}
 
-	if jsonSchema.Type == "array" && jsonSchema.Definitions != nil {
+	if jsonSchema.Definitions != nil {
 		jsonSchema.Definitions = nil
 	}
 
@@ -704,6 +738,17 @@ func (r Router[_, _, _]) getSchemaFromInterface(v any, allowAdditionalProperties
 	data, err := jsonSchema.MarshalJSON()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal jsonschema: %w", err)
+	}
+
+	// Strip JSON Schema-only fields for OpenAPI 3.0 compatibility
+	var mainMap map[string]any
+	if err := json.Unmarshal(data, &mainMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal schema into map: %w", err)
+	}
+	stripJSONSchemaOnlyFields(mainMap)
+	data, err = json.Marshal(mainMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal cleaned schema: %w", err)
 	}
 
 	// Unmarshal the main schema JSON into an openapi3.Schema


### PR DESCRIPTION
Adds stripJSONSchemaOnlyFields function to remove JSON Schema-only fields (contentEncoding, contentMediaType, contentSchema, $defs) that are not supported in OpenAPI 3.0. Converts contentEncoding: "base64" to format: "byte" as the OpenAPI equivalent.

Also unconditionally clears Definitions after processing instead of only for array types.

---

<!-- kody-pr-summary:start -->
Strip JSON Schema-only fields for OpenAPI 3.0 compatibility

This PR adds a `stripJSONSchemaOnlyFields` function that recursively removes JSON Schema fields not supported by OpenAPI 3.0 from generated schema definitions. Specifically:

- **`contentEncoding`**: Removed; when set to `"base64"`, it is converted to `format: "byte"` (the OpenAPI 3.0 equivalent)
- **`contentMediaType`**: Removed (no OpenAPI 3.0 equivalent)
- **`contentSchema`**: Removed (no OpenAPI 3.0 equivalent)
- **`$defs`**: Removed (OpenAPI 3.0 uses `components/schemas` instead)

The stripping is applied both to individual definitions and to the main schema before they are unmarshaled into `openapi3.Schema` objects, preventing validation errors when JSON Schema types use these fields.

Additionally, the condition for clearing `jsonSchema.Definitions` was broadened from only array-typed schemas to all schemas, and a minor `fmt.Errorf` → `errors.New` cleanup was included.
<!-- kody-pr-summary:end -->